### PR TITLE
Ignore six

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - pip --version
 
   # Setup virtualenv
-  - sudo -H pip install -U virtualenv
+  - sudo -H pip install -U virtualenv --ignore-installed six
   - virtualenv --version
   - virtualenv .venv
   - source .venv/bin/activate


### PR DESCRIPTION
Added a flag to ignore six and avoid an issue that causes pip install to fail due to conflicts with six.