### PR TITLE
Bug/brew uninstall travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - curl -sLO "${URL}"
   - chmod +x uninstall
   - yes | ./uninstall --force
-  - rm -rf /usr/local/Homebrew
+  - sudo rm -rf /usr/local/Homebrew
   - sudo rm -rf /usr/local/Caskroom
   - sudo rm -rf /usr/local/bin/brew
   - sudo rm -rf /Library/Developer/CommandLineTools

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - URL=https://raw.githubusercontent.com/Homebrew/install/master/uninstall
   - curl -sLO "${URL}"
   - chmod +x uninstall
-  - ./uninstall --force
+  - yes | ./uninstall --force
   - rm -rf /usr/local/Homebrew
   - sudo rm -rf /usr/local/Caskroom
   - sudo rm -rf /usr/local/bin/brew

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
   - sudo rm -rf /usr/local/Homebrew
   - sudo rm -rf /usr/local/Caskroom
   - sudo rm -rf /usr/local/bin/brew
+  - sudo rm -rf /usr/local/Cellar
   - sudo rm -rf /Library/Developer/CommandLineTools
 
   # Install pip


### PR DESCRIPTION
Brew uninstall script prompts the user for confirmation before proceeding. This causes CI builds to hang while waiting for user input. 

Calling the command line tool `yes` and piping with the uninstall script execution to prevent the issue.